### PR TITLE
"Force Author Tags First"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-*.user
+*.user.*
 doc/
-WiseTagger.pro.user.6820b68.4.10-pre1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.user
 doc/
+WiseTagger.pro.user.6820b68.4.10-pre1

--- a/resources/i18n/English.ts
+++ b/resources/i18n/English.ts
@@ -745,521 +745,531 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../../src/window.cpp" line="78"/>
+        <location filename="../../src/window.cpp" line="79"/>
         <source>&amp;Open File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="79"/>
+        <location filename="../../src/window.cpp" line="80"/>
         <source>Open &amp;Folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="80"/>
+        <location filename="../../src/window.cpp" line="81"/>
         <source>&amp;Delete Current Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="81"/>
+        <location filename="../../src/window.cpp" line="82"/>
         <source>Open Imageboard &amp;Post...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="82"/>
+        <location filename="../../src/window.cpp" line="83"/>
         <source>&amp;Reverse Search Image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="83"/>
+        <location filename="../../src/window.cpp" line="84"/>
         <source>&amp;Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="85"/>
+        <location filename="../../src/window.cpp" line="86"/>
         <source>&amp;Next Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="86"/>
+        <location filename="../../src/window.cpp" line="87"/>
         <source>&amp;Previous Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="87"/>
+        <location filename="../../src/window.cpp" line="88"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="88"/>
+        <location filename="../../src/window.cpp" line="89"/>
         <source>Save and Open Next Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="89"/>
+        <location filename="../../src/window.cpp" line="90"/>
         <source>Save and Open Previous Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="90"/>
+        <location filename="../../src/window.cpp" line="91"/>
         <source>&amp;Go To File Number...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="92"/>
-        <location filename="../../src/window.cpp" line="885"/>
+        <location filename="../../src/window.cpp" line="93"/>
+        <location filename="../../src/window.cpp" line="896"/>
         <source>Save Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="91"/>
-        <location filename="../../src/window.cpp" line="905"/>
+        <location filename="../../src/window.cpp" line="92"/>
+        <location filename="../../src/window.cpp" line="916"/>
         <source>Open Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="84"/>
+        <location filename="../../src/window.cpp" line="85"/>
         <source>Hide to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="93"/>
+        <location filename="../../src/window.cpp" line="94"/>
         <source>&amp;Apply Tag Fixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="94"/>
+        <location filename="../../src/window.cpp" line="95"/>
         <source>Fetch Imageboard Tags...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="95"/>
+        <location filename="../../src/window.cpp" line="96"/>
         <source>Open &amp;Containing Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="96"/>
+        <location filename="../../src/window.cpp" line="97"/>
         <source>&amp;Reload Tag File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="97"/>
+        <location filename="../../src/window.cpp" line="98"/>
         <source>Open Tag File &amp;Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="98"/>
+        <location filename="../../src/window.cpp" line="99"/>
         <source>&amp;Edit Tag File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="99"/>
+        <location filename="../../src/window.cpp" line="100"/>
         <source>Edit Temporary Tags...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="100"/>
+        <location filename="../../src/window.cpp" line="101"/>
         <source>Re&amp;place Imageboard Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="101"/>
+        <location filename="../../src/window.cpp" line="102"/>
         <source>Re&amp;store Imageboard Tags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/window.cpp" line="103"/>
+        <source>&amp;Force Author Tags First</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/window.cpp" line="105"/>
         <source>Show &amp;WiseTagger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="104"/>
+        <location filename="../../src/window.cpp" line="106"/>
         <source>Mi&amp;nimal View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="109"/>
+        <location filename="../../src/window.cpp" line="111"/>
         <source>By File &amp;Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="110"/>
+        <location filename="../../src/window.cpp" line="112"/>
         <source>By File &amp;Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="111"/>
+        <location filename="../../src/window.cpp" line="113"/>
         <source>By Modification &amp;Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="112"/>
+        <location filename="../../src/window.cpp" line="114"/>
         <source>By File &amp;Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="113"/>
+        <location filename="../../src/window.cpp" line="115"/>
         <source>&amp;About...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="114"/>
+        <location filename="../../src/window.cpp" line="116"/>
         <source>About &amp;Qt...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="115"/>
+        <location filename="../../src/window.cpp" line="117"/>
         <source>&amp;Help...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="118"/>
+        <location filename="../../src/window.cpp" line="120"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="119"/>
+        <location filename="../../src/window.cpp" line="121"/>
         <source>&amp;Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="120"/>
+        <location filename="../../src/window.cpp" line="122"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="121"/>
+        <location filename="../../src/window.cpp" line="123"/>
         <source>&amp;Sort Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="122"/>
+        <location filename="../../src/window.cpp" line="124"/>
         <source>&amp;Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="124"/>
+        <location filename="../../src/window.cpp" line="126"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="152"/>
+        <location filename="../../src/window.cpp" line="154"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="169"/>
+        <location filename="../../src/window.cpp" line="171"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="202"/>
+        <location filename="../../src/window.cpp" line="204"/>
         <source>Invalid proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="203"/>
+        <location filename="../../src/window.cpp" line="205"/>
         <source>&lt;p&gt;Proxy URL &lt;em&gt;&lt;code&gt;%1&lt;/code&gt;&lt;/em&gt; is invalid. Proxy &lt;b&gt;will not&lt;/b&gt; be used!&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="263"/>
+        <location filename="../../src/window.cpp" line="265"/>
         <source>In directory:  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="351"/>
+        <location filename="../../src/window.cpp" line="353"/>
         <source>Uploading %1 to iqdb.org...  %2% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="365"/>
+        <location filename="../../src/window.cpp" line="367"/>
         <source>Fetching tags from %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="374"/>
+        <location filename="../../src/window.cpp" line="376"/>
         <source>Done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="638"/>
+        <location filename="../../src/window.cpp" line="642"/>
         <source>Version %1 is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="639"/>
+        <location filename="../../src/window.cpp" line="643"/>
         <source>&lt;h3&gt;Updated version available: v%1&lt;/h3&gt;&lt;p&gt;&lt;a href=&quot;%2&quot;&gt;Click here to download new version&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="714"/>
+        <location filename="../../src/window.cpp" line="718"/>
         <source>Failed to start command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="715"/>
+        <location filename="../../src/window.cpp" line="719"/>
         <source>&lt;p&gt;Failed to launch command &lt;b&gt;%1&lt;/b&gt;:&lt;/p&gt;&lt;p&gt;Could not start &lt;code&gt;%2&lt;/code&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="728"/>
+        <location filename="../../src/window.cpp" line="732"/>
         <source>Ctrl+D</source>
         <comment>File|Open Directory</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="735"/>
+        <location filename="../../src/window.cpp" line="739"/>
         <source>Ctrl+A</source>
         <comment>Fix tags</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="736"/>
+        <location filename="../../src/window.cpp" line="740"/>
         <source>Ctrl+P</source>
         <comment>Open post</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="737"/>
+        <location filename="../../src/window.cpp" line="741"/>
         <source>Ctrl+F</source>
         <comment>Reverse search</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="738"/>
+        <location filename="../../src/window.cpp" line="742"/>
         <source>Ctrl+Shift+F</source>
         <comment>Fetch tags</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="739"/>
+        <location filename="../../src/window.cpp" line="743"/>
         <source>Ctrl+L</source>
         <comment>Open file location</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="748"/>
+        <location filename="../../src/window.cpp" line="752"/>
         <source>Open imageboard post of this image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="749"/>
+        <location filename="../../src/window.cpp" line="753"/>
         <source>Upload this image to iqdb.org and open search results page in default browser.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="750"/>
+        <location filename="../../src/window.cpp" line="754"/>
         <source>Open folder where this image is located.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="751"/>
+        <location filename="../../src/window.cpp" line="755"/>
         <source>Open folder where current tag file is located.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="753"/>
+        <location filename="../../src/window.cpp" line="757"/>
         <source>Open current tag file in default text editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="754"/>
+        <location filename="../../src/window.cpp" line="758"/>
         <source>Toggle replacing certain imageboard tags with their shorter version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="755"/>
+        <location filename="../../src/window.cpp" line="759"/>
         <source>Toggle restoring imageboard tags back to their original version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="770"/>
+        <location filename="../../src/window.cpp" line="760"/>
+        <source>Toggle forcing the author tag to be the first tag in the filename.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/window.cpp" line="776"/>
         <source>Search results page opened in default browser.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="770"/>
+        <location filename="../../src/window.cpp" line="776"/>
         <source>IQDB upload finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="798"/>
+        <location filename="../../src/window.cpp" line="804"/>
         <source>Tag file changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="799"/>
+        <location filename="../../src/window.cpp" line="805"/>
         <source>Tag file has been edited or removed.
 All changes successfully applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="887"/>
-        <location filename="../../src/window.cpp" line="907"/>
+        <location filename="../../src/window.cpp" line="898"/>
+        <location filename="../../src/window.cpp" line="918"/>
         <source>Session Files (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="893"/>
+        <location filename="../../src/window.cpp" line="904"/>
         <source>Save Session Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="894"/>
+        <location filename="../../src/window.cpp" line="905"/>
         <source>&lt;p&gt;Could not save session to &lt;b&gt;%1&lt;/b&gt;.&lt;/p&gt;&lt;p&gt;Check file permissions.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="913"/>
+        <location filename="../../src/window.cpp" line="924"/>
         <source>Enter Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="914"/>
+        <location filename="../../src/window.cpp" line="925"/>
         <source>Enter file number to open:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="921"/>
+        <location filename="../../src/window.cpp" line="932"/>
         <source>Notifications  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="921"/>
+        <location filename="../../src/window.cpp" line="932"/>
         <source>Notifications: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="936"/>
+        <location filename="../../src/window.cpp" line="947"/>
         <source>&lt;p&gt;New tags were found, ordered by number of times used:&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="943"/>
+        <location filename="../../src/window.cpp" line="954"/>
         <source>Check Notifications menu for list of added tags.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="956"/>
+        <location filename="../../src/window.cpp" line="967"/>
         <source>&lt;h2&gt;Could not locate suitable tag file&lt;/h2&gt;&lt;p&gt;You can still browse and rename files, but tag autocomplete will not work.&lt;/p&gt;&lt;hr&gt;WiseTagger will look for &lt;em&gt;tag files&lt;/em&gt; in directory of the currently opened file and in directories directly above it.&lt;p&gt;Tag files we looked for:&lt;dd&gt;&lt;dl&gt;Appending tag file: &lt;b&gt;%1&lt;/b&gt;&lt;/dl&gt;&lt;dl&gt;Overriding tag file: &lt;b&gt;%2&lt;/b&gt;&lt;/dl&gt;&lt;/dd&gt;&lt;/p&gt;&lt;p&gt;Directories where we looked for them, in search order:&lt;ol&gt;%3&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/0xb8/WiseTagger#tag-file-selection&quot;&gt;Appending and overriding tag files documentation&lt;/a&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="984"/>
+        <location filename="../../src/window.cpp" line="995"/>
         <source>Tag file syntax error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="984"/>
+        <location filename="../../src/window.cpp" line="995"/>
         <source>Regular expression syntax error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="985"/>
+        <location filename="../../src/window.cpp" line="996"/>
         <source>&lt;h2&gt;Regular expression syntax error&lt;/h2&gt;&lt;p&gt;At column %1: %2&lt;/p&gt;&lt;pre style=&quot;font-family: Consolas, &quot;Lucida Console&quot;, Monaco,monospace,monospace;&quot;&gt;%3
 
 &lt;span style=&quot;color: red&quot;&gt;%4&lt;/span&gt;&lt;pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="997"/>
+        <location filename="../../src/window.cpp" line="1008"/>
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="997"/>
+        <location filename="../../src/window.cpp" line="1008"/>
         <source>Error connecting to %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1022"/>
+        <location filename="../../src/window.cpp" line="1033"/>
         <source>Tag Fetching Done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1212"/>
+        <location filename="../../src/window.cpp" line="1226"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1216"/>
+        <location filename="../../src/window.cpp" line="1230"/>
         <source>enabled</source>
         <comment>portable</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1216"/>
+        <location filename="../../src/window.cpp" line="1230"/>
         <source>disabled</source>
         <comment>portable</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="102"/>
+        <location filename="../../src/window.cpp" line="104"/>
         <source>P&amp;references...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="105"/>
+        <location filename="../../src/window.cpp" line="107"/>
         <source>&amp;Statusbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="106"/>
+        <location filename="../../src/window.cpp" line="108"/>
         <source>&amp;Fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="107"/>
+        <location filename="../../src/window.cpp" line="109"/>
         <source>&amp;Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="108"/>
+        <location filename="../../src/window.cpp" line="110"/>
         <source>Tag &amp;Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="116"/>
+        <location filename="../../src/window.cpp" line="118"/>
         <source>&amp;Statistics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="123"/>
+        <location filename="../../src/window.cpp" line="125"/>
         <source>&amp;Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="154"/>
+        <location filename="../../src/window.cpp" line="156"/>
         <source>Image Files (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="637"/>
+        <location filename="../../src/window.cpp" line="641"/>
         <source>New version available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="752"/>
+        <location filename="../../src/window.cpp" line="756"/>
         <source>Reload changes in tag files and search for newly added tag files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="943"/>
+        <location filename="../../src/window.cpp" line="954"/>
         <source>New tags added</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="954"/>
+        <location filename="../../src/window.cpp" line="965"/>
         <source>Tag file not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="955"/>
+        <location filename="../../src/window.cpp" line="966"/>
         <source>Could not locate suitable tag file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1200"/>
+        <location filename="../../src/window.cpp" line="1214"/>
         <source>About %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/resources/i18n/Russian.ts
+++ b/resources/i18n/Russian.ts
@@ -752,353 +752,363 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../../src/window.cpp" line="78"/>
+        <location filename="../../src/window.cpp" line="79"/>
         <source>&amp;Open File...</source>
         <translation>&amp;Открыть файл...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="79"/>
+        <location filename="../../src/window.cpp" line="80"/>
         <source>Open &amp;Folder...</source>
         <translation>Открыть &amp;папку...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="80"/>
+        <location filename="../../src/window.cpp" line="81"/>
         <source>&amp;Delete Current Image</source>
         <translation>&amp;Удалить текущее изображение</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="81"/>
+        <location filename="../../src/window.cpp" line="82"/>
         <source>Open Imageboard &amp;Post...</source>
         <translation>Открыть &amp;пост имиджборды...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="82"/>
+        <location filename="../../src/window.cpp" line="83"/>
         <source>&amp;Reverse Search Image...</source>
         <translation>Поис&amp;к изображения...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="83"/>
+        <location filename="../../src/window.cpp" line="84"/>
         <source>&amp;Exit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="85"/>
+        <location filename="../../src/window.cpp" line="86"/>
         <source>&amp;Next Image</source>
         <translation>&amp;Следующее изображение</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="86"/>
+        <location filename="../../src/window.cpp" line="87"/>
         <source>&amp;Previous Image</source>
         <translation>&amp;Предыдущее изображение</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="87"/>
+        <location filename="../../src/window.cpp" line="88"/>
         <source>&amp;Save</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="88"/>
+        <location filename="../../src/window.cpp" line="89"/>
         <source>Save and Open Next Image</source>
         <translation>Сохранить и открыть следующее изображение</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="89"/>
+        <location filename="../../src/window.cpp" line="90"/>
         <source>Save and Open Previous Image</source>
         <translation>Сохранить и открыть предыдущее изображение</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="92"/>
-        <location filename="../../src/window.cpp" line="885"/>
+        <location filename="../../src/window.cpp" line="93"/>
+        <location filename="../../src/window.cpp" line="896"/>
         <source>Save Session</source>
         <translation>Сохранить сессию</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="91"/>
-        <location filename="../../src/window.cpp" line="905"/>
+        <location filename="../../src/window.cpp" line="92"/>
+        <location filename="../../src/window.cpp" line="916"/>
         <source>Open Session</source>
         <translation>Открыть сессию</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="95"/>
+        <location filename="../../src/window.cpp" line="96"/>
         <source>Open &amp;Containing Folder</source>
         <translation>&amp;Открыть расположение файла</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="96"/>
+        <location filename="../../src/window.cpp" line="97"/>
         <source>&amp;Reload Tag File</source>
         <translation>Перезагрузить файл &amp;тегов</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="100"/>
+        <location filename="../../src/window.cpp" line="101"/>
         <source>Re&amp;place Imageboard Tags</source>
         <translation>&amp;Замещать теги имиджборд</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="101"/>
+        <location filename="../../src/window.cpp" line="102"/>
         <source>Re&amp;store Imageboard Tags</source>
         <translation>&amp;Восстанавливать теги имиджборд</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="105"/>
+        <location filename="../../src/window.cpp" line="107"/>
         <source>&amp;Statusbar</source>
         <translation>&amp;Строка состояния</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="106"/>
+        <location filename="../../src/window.cpp" line="108"/>
         <source>&amp;Fullscreen</source>
         <translation>&amp;Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="107"/>
+        <location filename="../../src/window.cpp" line="109"/>
         <source>&amp;Menu</source>
         <translation>&amp;Меню</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="108"/>
+        <location filename="../../src/window.cpp" line="110"/>
         <source>Tag &amp;Input</source>
         <translation>Поле &amp;ввода тегов</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="116"/>
+        <location filename="../../src/window.cpp" line="118"/>
         <source>&amp;Statistics...</source>
         <translation>&amp;Статистика...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="123"/>
+        <location filename="../../src/window.cpp" line="125"/>
         <source>&amp;Commands</source>
         <translation>&amp;Команды</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="113"/>
+        <location filename="../../src/window.cpp" line="115"/>
         <source>&amp;About...</source>
         <translation>&amp;О программе...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="114"/>
+        <location filename="../../src/window.cpp" line="116"/>
         <source>About &amp;Qt...</source>
         <translation>О &amp;Qt...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="115"/>
+        <location filename="../../src/window.cpp" line="117"/>
         <source>&amp;Help...</source>
         <translation>&amp;Справка...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="118"/>
+        <location filename="../../src/window.cpp" line="120"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="119"/>
+        <location filename="../../src/window.cpp" line="121"/>
         <source>&amp;Navigation</source>
         <translation>&amp;Навигация</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="120"/>
+        <location filename="../../src/window.cpp" line="122"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="122"/>
+        <location filename="../../src/window.cpp" line="124"/>
         <source>&amp;Options</source>
         <translation>&amp;Опции</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="102"/>
+        <location filename="../../src/window.cpp" line="104"/>
         <source>P&amp;references...</source>
         <translation>&amp;Настройки...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="84"/>
+        <location filename="../../src/window.cpp" line="85"/>
         <source>Hide to tray</source>
         <translation>Спрятать в трей</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="94"/>
+        <location filename="../../src/window.cpp" line="95"/>
         <source>Fetch Imageboard Tags...</source>
         <translation>Загрузить теги с имиджборды...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="97"/>
+        <location filename="../../src/window.cpp" line="98"/>
         <source>Open Tag File &amp;Location</source>
         <translation>Открыть расположение &amp;файла тегов</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="98"/>
+        <location filename="../../src/window.cpp" line="99"/>
         <source>&amp;Edit Tag File</source>
         <translation>&amp;Редактировать файл тегов</translation>
     </message>
     <message>
         <location filename="../../src/window.cpp" line="103"/>
+        <source>&amp;Force Author Tags First</source>
+        <translation>&amp;Помещать тег автора в начало</translation>
+    </message>
+    <message>
+        <location filename="../../src/window.cpp" line="105"/>
         <source>Show &amp;WiseTagger</source>
         <translation>Показать &amp;WiseTagger</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="104"/>
+        <location filename="../../src/window.cpp" line="106"/>
         <source>Mi&amp;nimal View</source>
         <translation>Ми&amp;нималистичный режим</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="109"/>
+        <location filename="../../src/window.cpp" line="111"/>
         <source>By File &amp;Name</source>
         <translation>&amp;Имя</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="110"/>
+        <location filename="../../src/window.cpp" line="112"/>
         <source>By File &amp;Type</source>
         <translation>&amp;Тип</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="111"/>
+        <location filename="../../src/window.cpp" line="113"/>
         <source>By Modification &amp;Date</source>
         <translation>&amp;Дата изменения</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="112"/>
+        <location filename="../../src/window.cpp" line="114"/>
         <source>By File &amp;Size</source>
         <translation>&amp;Размер</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="121"/>
+        <location filename="../../src/window.cpp" line="123"/>
         <source>&amp;Sort Queue</source>
         <translation>&amp;Сортировать</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="124"/>
+        <location filename="../../src/window.cpp" line="126"/>
         <source>&amp;Help</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="152"/>
+        <location filename="../../src/window.cpp" line="154"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="154"/>
+        <location filename="../../src/window.cpp" line="156"/>
         <source>Image Files (%1)</source>
         <translation>Файлы изображений (%1)</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="202"/>
+        <location filename="../../src/window.cpp" line="204"/>
         <source>Invalid proxy</source>
         <translation>Ошибка прокси</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="203"/>
+        <location filename="../../src/window.cpp" line="205"/>
         <source>&lt;p&gt;Proxy URL &lt;em&gt;&lt;code&gt;%1&lt;/code&gt;&lt;/em&gt; is invalid. Proxy &lt;b&gt;will not&lt;/b&gt; be used!&lt;/p&gt;</source>
         <translation>&lt;p&gt;URL прокси&lt;em&gt;&lt;code&gt;%1&lt;/code&gt;&lt;/em&gt; некорректен. Прокси &lt;b&gt;не будет использована!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="365"/>
+        <location filename="../../src/window.cpp" line="367"/>
         <source>Fetching tags from %1...</source>
         <translation>Загрузка тегов с %1...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="638"/>
+        <location filename="../../src/window.cpp" line="642"/>
         <source>Version %1 is available.</source>
         <translation>Доступна версия %1.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="639"/>
+        <location filename="../../src/window.cpp" line="643"/>
         <source>&lt;h3&gt;Updated version available: v%1&lt;/h3&gt;&lt;p&gt;&lt;a href=&quot;%2&quot;&gt;Click here to download new version&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Доступна новая версия: v%1&lt;/h3&gt;&lt;p&gt;&lt;a href=&quot;%2&quot;&gt;Нажмите здесь, чтобы загрузить новую версию&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="714"/>
+        <location filename="../../src/window.cpp" line="718"/>
         <source>Failed to start command</source>
         <translation>Не удалось запустить команду</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="715"/>
+        <location filename="../../src/window.cpp" line="719"/>
         <source>&lt;p&gt;Failed to launch command &lt;b&gt;%1&lt;/b&gt;:&lt;/p&gt;&lt;p&gt;Could not start &lt;code&gt;%2&lt;/code&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Не удалось выполнить команду &lt;b&gt;%1&lt;/b&gt;:&lt;/p&gt;&lt;p&gt;Невозможно запустить &lt;code&gt;%2&lt;/code&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="738"/>
+        <location filename="../../src/window.cpp" line="742"/>
         <source>Ctrl+Shift+F</source>
         <comment>Fetch tags</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="752"/>
+        <location filename="../../src/window.cpp" line="756"/>
         <source>Reload changes in tag files and search for newly added tag files.</source>
         <translation>Перезагрузить измененные файлы тегов и искать добавленные файлы тегов.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="770"/>
+        <location filename="../../src/window.cpp" line="760"/>
+        <source>Toggle forcing the author tag to be the first tag in the filename.</source>
+        <translation>Включить перестановку тегов автора в начало результирующего имени файла.</translation>
+    </message>
+    <message>
+        <location filename="../../src/window.cpp" line="776"/>
         <source>Search results page opened in default browser.</source>
         <translation>Результаты поиска были открыты в браузере по умолчанию.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="798"/>
+        <location filename="../../src/window.cpp" line="804"/>
         <source>Tag file changed</source>
         <translation>Файл тегов изменён</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="799"/>
+        <location filename="../../src/window.cpp" line="805"/>
         <source>Tag file has been edited or removed.
 All changes successfully applied.</source>
         <translation>Файл тегов был редактирован или удален.
 Все изменения успешно применены.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="887"/>
-        <location filename="../../src/window.cpp" line="907"/>
+        <location filename="../../src/window.cpp" line="898"/>
+        <location filename="../../src/window.cpp" line="918"/>
         <source>Session Files (%1)</source>
         <translation>Файлы сессий (%1)</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="893"/>
+        <location filename="../../src/window.cpp" line="904"/>
         <source>Save Session Error</source>
         <translation>Не удалось сохранить сессию</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="894"/>
+        <location filename="../../src/window.cpp" line="905"/>
         <source>&lt;p&gt;Could not save session to &lt;b&gt;%1&lt;/b&gt;.&lt;/p&gt;&lt;p&gt;Check file permissions.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Не удалось сохранить сессию в файл &lt;b&gt;%1&lt;/b&gt;.&lt;/p&gt;&lt;p&gt;Проверьте права доступа.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="913"/>
+        <location filename="../../src/window.cpp" line="924"/>
         <source>Enter Number</source>
         <translation>Введите число</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="914"/>
+        <location filename="../../src/window.cpp" line="925"/>
         <source>Enter file number to open:</source>
         <translation>Введите номер файла:</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="921"/>
+        <location filename="../../src/window.cpp" line="932"/>
         <source>Notifications  </source>
         <translation>Уведомления  </translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="921"/>
+        <location filename="../../src/window.cpp" line="932"/>
         <source>Notifications: %1</source>
         <translation>Уведомлений: %1</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="936"/>
+        <location filename="../../src/window.cpp" line="947"/>
         <source>&lt;p&gt;New tags were found, ordered by number of times used:&lt;/p&gt;</source>
         <translation>&lt;p&gt;Найдены новые теги, в порядке убывания частоты использования:&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="943"/>
+        <location filename="../../src/window.cpp" line="954"/>
         <source>Check Notifications menu for list of added tags.</source>
         <translation>Откройте меню уведомлений, чтобы просмотреть список новых тегов.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="984"/>
+        <location filename="../../src/window.cpp" line="995"/>
         <source>Tag file syntax error</source>
         <translation>Синтаксическая ошибка в файле тегов</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="984"/>
+        <location filename="../../src/window.cpp" line="995"/>
         <source>Regular expression syntax error</source>
         <translation>Синтаксическая ошибка в регулярном выражении</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="985"/>
+        <location filename="../../src/window.cpp" line="996"/>
         <source>&lt;h2&gt;Regular expression syntax error&lt;/h2&gt;&lt;p&gt;At column %1: %2&lt;/p&gt;&lt;pre style=&quot;font-family: Consolas, &quot;Lucida Console&quot;, Monaco,monospace,monospace;&quot;&gt;%3
 
 &lt;span style=&quot;color: red&quot;&gt;%4&lt;/span&gt;&lt;pre&gt;</source>
@@ -1107,169 +1117,169 @@ All changes successfully applied.</source>
 &lt;span style=&quot;color: red&quot;&gt;%4&lt;/span&gt;&lt;pre&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="997"/>
+        <location filename="../../src/window.cpp" line="1008"/>
         <source>Network error</source>
         <translation>Ошибка соединения</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="997"/>
+        <location filename="../../src/window.cpp" line="1008"/>
         <source>Error connecting to %1: %2</source>
         <translation>Не удалось подключиться к %1: %2</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1022"/>
+        <location filename="../../src/window.cpp" line="1033"/>
         <source>Tag Fetching Done.</source>
         <translation>Загрузка тегов завершена.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1200"/>
+        <location filename="../../src/window.cpp" line="1214"/>
         <source>About %1</source>
         <translation>О программе %1</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="169"/>
+        <location filename="../../src/window.cpp" line="171"/>
         <source>Open Directory</source>
         <translation>Открыть папку</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="351"/>
+        <location filename="../../src/window.cpp" line="353"/>
         <source>Uploading %1 to iqdb.org...  %2% complete</source>
         <translation>Загрузка %1 на iqdb.org... загружено %2%</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="956"/>
+        <location filename="../../src/window.cpp" line="967"/>
         <source>&lt;h2&gt;Could not locate suitable tag file&lt;/h2&gt;&lt;p&gt;You can still browse and rename files, but tag autocomplete will not work.&lt;/p&gt;&lt;hr&gt;WiseTagger will look for &lt;em&gt;tag files&lt;/em&gt; in directory of the currently opened file and in directories directly above it.&lt;p&gt;Tag files we looked for:&lt;dd&gt;&lt;dl&gt;Appending tag file: &lt;b&gt;%1&lt;/b&gt;&lt;/dl&gt;&lt;dl&gt;Overriding tag file: &lt;b&gt;%2&lt;/b&gt;&lt;/dl&gt;&lt;/dd&gt;&lt;/p&gt;&lt;p&gt;Directories where we looked for them, in search order:&lt;ol&gt;%3&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/0xb8/WiseTagger#tag-file-selection&quot;&gt;Appending and overriding tag files documentation&lt;/a&gt;&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Подходящий файл тегов не обнаружен&lt;/h2&gt;&lt;p&gt;Вы сможете просматривать и переименовывать файлы, однако автодополнение тегов не будет работать.&lt;/p&gt;&lt;hr&gt;WiseTagger ищет &lt;em&gt;файлы тегов&lt;/em&gt; в папке текущего изображения, и во всех папках выше.&lt;p&gt;Названия файлов тегов:&lt;dd&gt;&lt;dl&gt;Нормальный файл: &lt;b&gt;%1&lt;/b&gt;&lt;/dl&gt;&lt;dl&gt;Переопределяющий файл: &lt;b&gt;%2&lt;/b&gt;&lt;/dl&gt;&lt;/dd&gt;&lt;/p&gt;&lt;p&gt;Папки, в которых производился поиск, по порядку:&lt;ol&gt;%3&lt;/ol&gt;&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/0xb8/WiseTagger#tag-file-selection&quot;&gt;Документация по добавляемым и переопределяемым файлам тегов&lt;/a&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1216"/>
+        <location filename="../../src/window.cpp" line="1230"/>
         <source>enabled</source>
         <comment>portable</comment>
         <translation>включен</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1216"/>
+        <location filename="../../src/window.cpp" line="1230"/>
         <source>disabled</source>
         <comment>portable</comment>
         <translation>выключен</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="374"/>
+        <location filename="../../src/window.cpp" line="376"/>
         <source>Done.</source>
         <translation>Готово.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="90"/>
+        <location filename="../../src/window.cpp" line="91"/>
         <source>&amp;Go To File Number...</source>
         <translation>Перейти к файлу под &amp;номером...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="93"/>
+        <location filename="../../src/window.cpp" line="94"/>
         <source>&amp;Apply Tag Fixes</source>
         <translation>&amp;Исправить теги</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="99"/>
+        <location filename="../../src/window.cpp" line="100"/>
         <source>Edit Temporary Tags...</source>
         <translation>Редактировать временные теги...</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="263"/>
+        <location filename="../../src/window.cpp" line="265"/>
         <source>In directory:  %1</source>
         <translation>В директории:  %1</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="637"/>
+        <location filename="../../src/window.cpp" line="641"/>
         <source>New version available</source>
         <translation>Доступна новая версия</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="728"/>
+        <location filename="../../src/window.cpp" line="732"/>
         <source>Ctrl+D</source>
         <comment>File|Open Directory</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="735"/>
+        <location filename="../../src/window.cpp" line="739"/>
         <source>Ctrl+A</source>
         <comment>Fix tags</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="736"/>
+        <location filename="../../src/window.cpp" line="740"/>
         <source>Ctrl+P</source>
         <comment>Open post</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="737"/>
+        <location filename="../../src/window.cpp" line="741"/>
         <source>Ctrl+F</source>
         <comment>Reverse search</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="739"/>
+        <location filename="../../src/window.cpp" line="743"/>
         <source>Ctrl+L</source>
         <comment>Open file location</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="748"/>
+        <location filename="../../src/window.cpp" line="752"/>
         <source>Open imageboard post of this image.</source>
         <translation>Открыть это изображение на странице имиджборды.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="749"/>
+        <location filename="../../src/window.cpp" line="753"/>
         <source>Upload this image to iqdb.org and open search results page in default browser.</source>
         <translation>Загрузить это изображение на iqdb.org и открыть страницу с результатом поиска в браузере по умолчанию.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="750"/>
+        <location filename="../../src/window.cpp" line="754"/>
         <source>Open folder where this image is located.</source>
         <translation>Открыть папку, в которой находится это изображение.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="751"/>
+        <location filename="../../src/window.cpp" line="755"/>
         <source>Open folder where current tag file is located.</source>
         <translation>Открыть папку, в которой расположен текущий файл тегов.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="753"/>
+        <location filename="../../src/window.cpp" line="757"/>
         <source>Open current tag file in default text editor.</source>
         <translation>Открыть текущий файл тегов в текстовом редакторе по-умолчанию.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="754"/>
+        <location filename="../../src/window.cpp" line="758"/>
         <source>Toggle replacing certain imageboard tags with their shorter version.</source>
         <translation>Включить замену тегов некоторых имиджборд на их более короткие версии.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="755"/>
+        <location filename="../../src/window.cpp" line="759"/>
         <source>Toggle restoring imageboard tags back to their original version.</source>
         <translation>Включить восстановление тегов имиджборд к их оригинальным версиям.</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="770"/>
+        <location filename="../../src/window.cpp" line="776"/>
         <source>IQDB upload finished</source>
         <translation>Загрузка файла завершена</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="943"/>
+        <location filename="../../src/window.cpp" line="954"/>
         <source>New tags added</source>
         <translation>Найдены новые теги</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="954"/>
+        <location filename="../../src/window.cpp" line="965"/>
         <source>Tag file not found</source>
         <translation>Файл тегов не найден</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="955"/>
+        <location filename="../../src/window.cpp" line="966"/>
         <source>Could not locate suitable tag file</source>
         <translation>Подходящий файл тегов не обнаружен</translation>
     </message>
     <message>
-        <location filename="../../src/window.cpp" line="1212"/>
+        <location filename="../../src/window.cpp" line="1226"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -101,9 +101,7 @@ void TagInput::fixTags(bool sort)
 		// due to C++ literal strings rules all backslashes inside the pattern string needs escaping with another backslash
 		// the pattern matches to (not-a-space-tab-newline)@AA - (not-a-space-tab-newline)@ZZ;
 		// the list is then prepended by those having ↑ and original entries of ↑ are removed
-		m_text_list = m_text_list.filter(QRegularExpression(R"~(
-									\[?[^ \t\n\r]+@[A-Z]{2}\]?
-									)~")) + m_text_list;
+		m_text_list = m_text_list.filter(QRegularExpression(R"~(\[?[^ \t\n\r]+@[A-Z]{2}\]?)~")) + m_text_list;
 		m_text_list.removeDuplicates();
 	}
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -96,6 +96,15 @@ void TagInput::fixTags(bool sort)
 		std::sort(id, m_text_list.end());
 	}
 
+	// if the author tag is present and should be forced to be first, move it first
+	if(settings.value(QStringLiteral("imageboard/force-author-first"), true).toBool()) {
+		// due to C++ literal strings rules all backslashes inside the pattern string needs escaping with another backslash
+		// the pattern matches to (not-a-space-tab-newline)@AA - (not-a-space-tab-newline)@ZZ;
+		// the list is then prepended by those having ↑ and original entries of ↑ are removed
+		m_text_list = m_text_list.filter(QRegularExpression("\\[?[^ \\t\\n\\r]+@[A-Z]{2}\\]?")) + m_text_list;
+		m_text_list.removeDuplicates();
+	}
+
 	auto newname = m_text_list.join(' ');
 	util::replace_special(newname);
 	updateText(newname);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -97,11 +97,13 @@ void TagInput::fixTags(bool sort)
 	}
 
 	// if the author tag is present and should be forced to be first, move it first
-	if(settings.value(QStringLiteral("imageboard/force-author-first"), true).toBool()) {
+	if(settings.value(QStringLiteral("imageboard/force-author-first"), false).toBool()) {
 		// due to C++ literal strings rules all backslashes inside the pattern string needs escaping with another backslash
 		// the pattern matches to (not-a-space-tab-newline)@AA - (not-a-space-tab-newline)@ZZ;
 		// the list is then prepended by those having ↑ and original entries of ↑ are removed
-		m_text_list = m_text_list.filter(QRegularExpression("\\[?[^ \\t\\n\\r]+@[A-Z]{2}\\]?")) + m_text_list;
+		m_text_list = m_text_list.filter(QRegularExpression(R"~(
+									\[?[^ \t\n\r]+@[A-Z]{2}\]?
+									)~")) + m_text_list;
 		m_text_list.removeDuplicates();
 	}
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -516,7 +516,7 @@ void Window::initSettings()
 
 	a_ib_replace.setChecked(sett.value(SETT_REPLACE_TAGS, false).toBool());
 	a_ib_restore.setChecked(sett.value(SETT_RESTORE_TAGS, true).toBool());
-	a_tag_forcefirst.setChecked(sett.value(SETT_FORCE_AUTHOR_FIRST, true).toBool());
+	a_tag_forcefirst.setChecked(sett.value(SETT_FORCE_AUTHOR_FIRST, false).toBool());
 	
 	m_show_current_directory = sett.value(SETT_SHOW_CURRENT_DIR, true).toBool();
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -62,6 +62,7 @@ namespace logging_category {
 
 #define SETT_REPLACE_TAGS       QStringLiteral("imageboard/replace-tags")
 #define SETT_RESTORE_TAGS       QStringLiteral("imageboard/restore-tags")
+#define SETT_FORCE_AUTHOR_FIRST	QStringLiteral("imageboard/force-author-first")
 
 #ifdef Q_OS_WIN
 #define SETT_LAST_VER_CHECK     QStringLiteral("last-version-check")
@@ -99,6 +100,7 @@ Window::Window(QWidget *_parent) : QMainWindow(_parent)
 	, a_edit_temp_tags(  tr("Edit Temporary Tags..."), nullptr)
 	, a_ib_replace(      tr("Re&place Imageboard Tags"), nullptr)
 	, a_ib_restore(      tr("Re&store Imageboard Tags"), nullptr)
+	, a_tag_forcefirst(  tr("&Force Author Tags First"), nullptr)
 	, a_show_settings(   tr("P&references..."), nullptr)
 	, a_view_normal(     tr("Show &WiseTagger"), nullptr)
 	, a_view_minimal(    tr("Mi&nimal View"), nullptr)
@@ -514,6 +516,8 @@ void Window::initSettings()
 
 	a_ib_replace.setChecked(sett.value(SETT_REPLACE_TAGS, false).toBool());
 	a_ib_restore.setChecked(sett.value(SETT_RESTORE_TAGS, true).toBool());
+	a_tag_forcefirst.setChecked(sett.value(SETT_FORCE_AUTHOR_FIRST, true).toBool());
+	
 	m_show_current_directory = sett.value(SETT_SHOW_CURRENT_DIR, true).toBool();
 
 	updateProxySettings();
@@ -745,17 +749,19 @@ void Window::createActions()
 	a_view_input.setShortcut(   QKeySequence(Qt::CTRL + Qt::Key_I));
 	a_go_to_number.setShortcut( QKeySequence(Qt::CTRL + Qt::Key_NumberSign));
 
-	a_open_post.setStatusTip(  tr("Open imageboard post of this image."));
-	a_iqdb_search.setStatusTip(tr("Upload this image to iqdb.org and open search results page in default browser."));
-	a_open_loc.setStatusTip(   tr("Open folder where this image is located."));
-	a_open_tags.setStatusTip(  tr("Open folder where current tag file is located."));
-	a_reload_tags.setStatusTip(tr("Reload changes in tag files and search for newly added tag files."));
-	a_edit_tags.setStatusTip(  tr("Open current tag file in default text editor."));
-	a_ib_replace.setStatusTip( tr("Toggle replacing certain imageboard tags with their shorter version."));
-	a_ib_restore.setStatusTip( tr("Toggle restoring imageboard tags back to their original version."));
+	a_open_post.setStatusTip(     tr("Open imageboard post of this image."));
+	a_iqdb_search.setStatusTip(   tr("Upload this image to iqdb.org and open search results page in default browser."));
+	a_open_loc.setStatusTip(      tr("Open folder where this image is located."));
+	a_open_tags.setStatusTip(     tr("Open folder where current tag file is located."));
+	a_reload_tags.setStatusTip(   tr("Reload changes in tag files and search for newly added tag files."));
+	a_edit_tags.setStatusTip(     tr("Open current tag file in default text editor."));
+	a_ib_replace.setStatusTip(    tr("Toggle replacing certain imageboard tags with their shorter version."));
+	a_ib_restore.setStatusTip(    tr("Toggle restoring imageboard tags back to their original version."));
+	a_tag_forcefirst.setStatusTip(tr("Toggle forcing the author tag to be the first tag in the filename."));
 
 	a_ib_replace.setCheckable(true);
 	a_ib_restore.setCheckable(true);
+	a_tag_forcefirst.setCheckable(true);
 	a_view_statusbar.setCheckable(true);
 	a_view_fullscreen.setCheckable(true);
 	a_view_minimal.setCheckable(true);
@@ -844,6 +850,11 @@ void Window::createActions()
 	{
 		QSettings s; s.setValue(SETT_RESTORE_TAGS, checked);
 	});
+	connect(&a_tag_forcefirst,  &QAction::triggered, [](bool checked)
+	{
+		QSettings s; s.setValue(SETT_FORCE_AUTHOR_FIRST, checked);
+	});
+	
 	connect(&a_view_statusbar, &QAction::triggered, this, [this](bool checked)
 	{
 		QSettings s; s.setValue(SETT_SHOW_STATUS, checked);
@@ -1065,6 +1076,7 @@ void Window::createMenus()
 	add_separator(menu_tray);
 	add_action(menu_tray, a_ib_replace);
 	add_action(menu_tray, a_ib_restore);
+	add_action(menu_tray, a_tag_forcefirst);
 	add_separator(menu_tray);
 	add_action(menu_tray, a_show_settings);
 	add_action(menu_tray, a_exit);
@@ -1116,6 +1128,8 @@ void Window::createMenus()
 	// Options menu actions
 	add_action(menu_options, a_ib_replace);
 	add_action(menu_options, a_ib_restore);
+	add_separator(menu_options);
+	add_action(menu_options, a_tag_forcefirst);
 	add_separator(menu_options);
 	add_action(menu_options, a_show_settings);
 

--- a/src/window.h
+++ b/src/window.h
@@ -136,6 +136,7 @@ private:
 	QAction a_edit_temp_tags;
 	QAction a_ib_replace;
 	QAction a_ib_restore;
+	QAction a_tag_forcefirst;
 	QAction a_show_settings;
 	QAction a_view_normal;
 	QAction a_view_minimal;


### PR DESCRIPTION
Implemented biased sorting - filename should be starting with author handles if present and the corresponding option was checked.

The "author handles" are described as having 0 or 1 opening square bracked, some characters (except SPACE, \n \r \t), one @, two uppercase letters and 0 or 1 closing square bracket:
name@AA - name@ZZ
[name@AA] - [name@ZZ].
