### PR TITLE
Fix for image rotation through the menu

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -184,7 +184,7 @@ bool Picture::loadMedia(const QString &filename)
 
 		if (m_rotation) {
 			QTransform t;
-			t.rotate(-90.0f * m_rotation);
+			t.rotate(90.0f * m_rotation);
 			m_pixmap = m_pixmap.transformed(t, Qt::FastTransformation);
 		}
 

--- a/src/picture.h
+++ b/src/picture.h
@@ -49,7 +49,7 @@ public:
 	/// Upscale small images to fit the widget size
 	bool upscalingEnabled() const;
 
-	/// Set image rotation in 90 degree increments clockwise.
+	/// Returns the image rotation state in 90 degree increments clockwise.
 	int rotation() const;
 
 	/// Set image rotation in 90 degree increments clockwise.

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1189,10 +1189,10 @@ void Window::createActions()
 	a_play_mute.setShortcut(    QKeySequence(Qt::Key_M));
 	a_go_to_number.setShortcut( QKeySequence(Qt::CTRL + Qt::Key_NumberSign));
 	a_edit_mode.setShortcut(    QKeySequence(Qt::Key_F2));
-	a_rotate_cw.setShortcut(    QKeySequence(Qt::CTRL + Qt::Key_Comma));
-	a_navigate_by_wheel.setShortcut(QKeySequence(Qt::Key_ScrollLock));
-	a_rotate_ccw.setShortcut(   QKeySequence(Qt::CTRL + Qt::Key_Period));
+	a_rotate_cw.setShortcut(    QKeySequence(Qt::CTRL + Qt::Key_Period));
+	a_rotate_ccw.setShortcut(   QKeySequence(Qt::CTRL + Qt::Key_Comma));
 	a_fit_to_screen.setShortcut(QKeySequence(Qt::CTRL + Qt::Key_0));
+	a_navigate_by_wheel.setShortcut(QKeySequence(Qt::Key_ScrollLock));
 
 	a_view_sort_name.setShortcut(QKeySequence(Qt::SHIFT + Qt::Key_S, Qt::Key_N));
 	a_view_sort_type.setShortcut(QKeySequence(Qt::SHIFT + Qt::Key_S, Qt::Key_T));


### PR DESCRIPTION
Set CW hotkey to PERIOD and CCW hotkey to COMMA while also flipping the sign for m_rotation multiplier in picture.cpp@187

Fixes #14